### PR TITLE
DateTime/ui: fix empty value error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For example, add the following to the top of `App.css`
 Bootstrap also provides `sass` or `less` files, so import as appropriate.
 
 ```js
-import DateTime from 'react-datetime-bootstrap';
+import { DateTime } from 'react-datetime-bootstrap';
 
 export default const MyRenderer = (props) => (
 	<div>

--- a/dist/index.js
+++ b/dist/index.js
@@ -16,6 +16,7 @@
 	Object.defineProperty(exports, "__esModule", {
 		value: true
 	});
+	exports.DateTime = undefined;
 
 	var _react2 = _interopRequireDefault(_react);
 
@@ -145,7 +146,7 @@
 			}, _this.updateValue = function (value) {
 				var format = _this.props.pickerOptions.format;
 
-				if (value !== undefined && value !== null) {
+				if (value !== undefined && value !== null && value.trim().length) {
 					_this.datePicker.date(value);
 					_this.textInputElement.value = (0, _moment2.default)(value).format(format);
 				} else {
@@ -273,5 +274,5 @@
 	};
 	;
 
-	exports.default = DateTime;
+	exports.DateTime = DateTime;
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-datetime-bootstrap",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "React DateTime picker with Bootstrap",
   "author": "Jaz Singh",
   "license": "MIT",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -4,7 +4,7 @@ import {shallow, mount, render} from 'enzyme';
 import {expect} from 'chai';
 import sinon from 'sinon';
 
-import DateTime from '../index';
+import {DateTime} from '../index';
 
 // Demo tests
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -113,7 +113,7 @@ class DateTime extends React.Component {
 	}
 	updateValue = (value) => {
 		const {pickerOptions: {format}} = this.props;
-		if (value !== undefined && value !== null) {
+		if (value !== undefined && value !== null && value.trim().length) {
 			this.datePicker.date(value);
 			this.textInputElement.value = moment(value).format(format);
 		} else {
@@ -168,4 +168,4 @@ class DateTime extends React.Component {
 	}
 };
 
-export default DateTime;
+export {DateTime};


### PR DESCRIPTION
Summary:
Ensure that empty value displays reasonable content in the input field
Fix #1

Change to export without `default`. Now must `import { DateTime }`
Fix #2