### PR TITLE
ui: clean up props, add `readOnly`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -197,12 +197,13 @@
 				var _props2 = this.props,
 				    name = _props2.name,
 				    placeholder = _props2.placeholder,
-				    helpBlock = _props2.helpBlock,
 				    disabled = _props2.disabled,
 				    required = _props2.required,
+				    readOnly = _props2.readOnly,
 				    bsStyle = _props2.bsStyle;
 				var id = this.id;
 
+				var bsClass = bsStyle ? 'has-' + bsStyle : '';
 				// Input needs to be inside a position relative element for datetimepicker to work.
 				return _react2.default.createElement(
 					'div',
@@ -210,11 +211,12 @@
 					_react2.default.createElement('input', {
 						id: id,
 						ref: this.setRef,
-						className: 'has-' + bsStyle + ' form-control date-time',
+						className: bsClass + ' form-control date-time',
 						type: 'text',
 						name: name,
 						required: required,
 						disabled: disabled,
+						readOnly: readOnly,
 						placeholder: placeholder,
 						onFocus: this.selectTextElementContent
 					})
@@ -227,11 +229,11 @@
 
 	DateTime.propTypes = {
 		placeholder: _propTypes2.default.string,
-		hasFeedback: _propTypes2.default.bool,
 		bsStyle: _propTypes2.default.oneOf(['', 'success', 'warning', 'error']),
 		onChange: _propTypes2.default.func,
 		disabled: _propTypes2.default.bool,
-		helpBlock: _propTypes2.default.any,
+		required: _propTypes2.default.bool,
+		readOnly: _propTypes2.default.bool,
 		value: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object]),
 
 		pickerOptions: _propTypes2.default.shape({
@@ -268,7 +270,6 @@
 	DateTime.nextId = 0;
 	DateTime.defaultProps = {
 		id: "react-datetime-bootstrap",
-		hasFeedback: false,
 		onChange: console.log,
 		pickerOptions: _extends({}, defaultPickerOptions)
 	};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-datetime-bootstrap",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "description": "React DateTime picker with Bootstrap",
   "author": "Jaz Singh",
   "license": "MIT",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -36,13 +36,13 @@ let nextId = 0;
 class DateTime extends React.Component {
 	static propTypes = {
 		placeholder: PropTypes.string,
-		hasFeedback: PropTypes.bool,
 		bsStyle: PropTypes.oneOf([
 			'', 'success', 'warning', 'error',
 		]),
 		onChange: PropTypes.func,
 		disabled: PropTypes.bool,
-		helpBlock: PropTypes.any,
+		required: PropTypes.bool,
+		readOnly: PropTypes.bool,
 		value: PropTypes.oneOfType([
 			PropTypes.string,
 			PropTypes.object,
@@ -88,7 +88,6 @@ class DateTime extends React.Component {
 	static nextId = 0;
 	static defaultProps = {
 		id: "react-datetime-bootstrap",
-		hasFeedback: false,
 		onChange: console.log,
 		pickerOptions: {...defaultPickerOptions},
 	}
@@ -143,23 +142,25 @@ class DateTime extends React.Component {
 		const {
 			name,
 			placeholder,
-			helpBlock,
 			disabled,
 			required,
+			readOnly,
 			bsStyle,
 		} = this.props;
 		const {id} = this;
+		const bsClass = bsStyle ? `has-${bsStyle}` : '';
 		// Input needs to be inside a position relative element for datetimepicker to work.
 		return (
 			<div style={{position: "relative"}}>
 				<input
 					id={id}
 					ref={this.setRef}
-					className={`has-${bsStyle} form-control date-time`}
+					className={`${bsClass} form-control date-time`}
 					type="text"
 					name={name}
 					required={required}
 					disabled={disabled}
+					readOnly={readOnly}
 					placeholder={placeholder}
 					onFocus={this.selectTextElementContent}
 				/>


### PR DESCRIPTION
Summary:
input field should support readOnly option
Fix #6
Clean up unused props, only insert bsStyle if provided
Fix #7